### PR TITLE
Some feedback and proposed fixes

### DIFF
--- a/Scripting/shell-script-example-pginstall.org
+++ b/Scripting/shell-script-example-pginstall.org
@@ -154,7 +154,7 @@ PG_END
 
 This script *does not fully automate a PostgreSQL installation!*
 - It only organizes it for a human to supervise
-- The options =-euv= allow a human to take over
+- The options =-eux= allow a human to take over
       - =-x= causes the shell to print each command before executing it
             - but after all "expansions", e.g. of variables
       - =-e= causes the shell to exit if a command fails

--- a/Scripting/shell-script-resilience.org
+++ b/Scripting/shell-script-resilience.org
@@ -206,9 +206,9 @@ failure.
 
 A top level script may need to alert humans that an important process has
 failed. This should /never/ be done by popping up a notification on a user's
-screen asking them to report an error! A script should be able to send a text,
-email, etc. or file a trouble ticket, etc. to bring attention to the problem by
-the right person in a timely fashion. Scripts can also monitor a trouble ticket
+screen asking them to report an error! A script should be able to bring attention
+to the problem to the right person in a timely fashion (e.g. by sending an
+email, filing a trouble ticket, etc). Scripts can also monitor a trouble ticket
 system or repeatedly check a system which is out of order and escalate an issue
 when fixes are not occurring within an expected timeframe.
 
@@ -263,9 +263,9 @@ but then the =wget= command could fail, so maybe we better do
 - How might we reverse any side effects before exiting?
 - How might we log or communicate any problems appropriately?
 - Do we care why a command might have failed?
-      - We have the wrong version of the program?
-      - The data given to it is not as expected
-      - We're missing permissions
+      - Do we have the wrong version of the program?
+      - Is the data provided to the progrma in the expected format?
+      - Are we missing permissions to perform a certain action?
 
 *** An Organized Semi-Automated Approach
 


### PR DESCRIPTION
The proposed changes should be pretty straightforward, mostly typos and rephrasings. 

I didn't think on more radical changes that could simplify the exposition, especially for learners that are being first exposed to this topic. I wasn't feeling 100% fresh for such a task today. 

Maybe we should iterate more over the file to come up with some other sections for the `shell script resilence` chapter. The `pginstall example` was much digestible by virtue of being an example and more concise.

This is exciting, already the `pginstall` ideas are leading to a great segway to introduce down the line reproducible tooling such as Nix/Guix. I think it is good priming to ease the fundamentals for those complex paradigms and pieces of software.